### PR TITLE
[WIP/Help Wanted] Compatibility with Boost > 1.66

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ env:
 
 before_script:
 - cmake --version
-- wget -O boost_1_66_0.tar.gz https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.tar.gz
-- tar xzf boost_1_66_0.tar.gz
-- cd boost_1_66_0
+- wget -O "boost_1_${BOOST_MINOR}_0.tar.gz" "https://dl.bintray.com/boostorg/release/1.${BOOST_MINOR}.0/source/boost_1_${BOOST_MINOR}_0.tar.gz"
+- tar xzf "boost_1_${BOOST_MINOR}_0.tar.gz"
+- cd "boost_1_${BOOST_MINOR}_0"
 - ./bootstrap.sh --with-libraries=system,thread,context,coroutine
 - mkdir build
 - ./b2 --build-dir=build
@@ -40,6 +40,8 @@ before_script:
 matrix:
   include:
   - name: clang 5 release
+    env:
+      - BOOST_MINOR=66
     script:
     - |
         cmake \
@@ -60,6 +62,8 @@ matrix:
     - examples/coro_pool
     - examples/sync_pool
   - name: gcc 7 debug+coverage
+    env:
+      - BOOST_MINOR=66
     script:
     - sudo pip install gcovr
     - |
@@ -78,3 +82,83 @@ matrix:
     - ctest -V -j $(nproc)
     after_success:
     - bash <(curl -s https://codecov.io/bash)
+  - name: clang 5 release1.67
+    env:
+      - BOOST_MINOR=67
+    script:
+      - |
+        cmake \
+            -D CMAKE_BUILD_TYPE=Release \
+            -D CMAKE_C_COMPILER=clang-5.0 \
+            -D CMAKE_CXX_COMPILER=clang++-5.0 \
+            -D CMAKE_C_COMPILER_LAUNCHER=ccache \
+            -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -D RESOURCE_POOL_BUILD_TESTS=ON \
+            -D RESOURCE_POOL_BUILD_EXAMPLES=ON \
+            -D RESOURCE_POOL_BUILD_BENCHMARKS=ON \
+            ${TRAVIS_BUILD_DIR}
+      - make -j $(nproc)
+      - ctest -V -j $(nproc)
+      - benchmarks/resource_pool_benchmark_async
+      - examples/async_pool
+      - examples/async_strand
+      - examples/coro_pool
+      - examples/sync_pool
+  - name: gcc 7 debug 1.67
+    env:
+      - BOOST_MINOR=67
+    script:
+      - sudo pip install gcovr
+      - |
+        cmake \
+            -D CMAKE_BUILD_TYPE=Debug \
+            -D CMAKE_C_COMPILER=gcc-7 \
+            -D CMAKE_CXX_COMPILER=g++-7 \
+            -D CMAKE_C_COMPILER_LAUNCHER=ccache \
+            -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -D RESOURCE_POOL_BUILD_TESTS=ON \
+            -D RESOURCE_POOL_BUILD_EXAMPLES=ON \
+            -D RESOURCE_POOL_BUILD_BENCHMARKS=ON \
+            ${TRAVIS_BUILD_DIR}
+      - make -j $(nproc)
+      - ctest -V -j $(nproc)
+  - name: clang 5 release 1.70
+    env:
+      - BOOST_MINOR=70
+    script:
+      - |
+        cmake \
+            -D CMAKE_BUILD_TYPE=Release \
+            -D CMAKE_C_COMPILER=clang-5.0 \
+            -D CMAKE_CXX_COMPILER=clang++-5.0 \
+            -D CMAKE_C_COMPILER_LAUNCHER=ccache \
+            -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -D RESOURCE_POOL_BUILD_TESTS=ON \
+            -D RESOURCE_POOL_BUILD_EXAMPLES=ON \
+            -D RESOURCE_POOL_BUILD_BENCHMARKS=ON \
+            ${TRAVIS_BUILD_DIR}
+      - make -j $(nproc)
+      - ctest -V -j $(nproc)
+      - benchmarks/resource_pool_benchmark_async
+      - examples/async_pool
+      - examples/async_strand
+      - examples/coro_pool
+      - examples/sync_pool
+  - name: gcc 7 debug+coverage 1.70
+    env:
+      - BOOST_MINOR=70
+    script:
+      - sudo pip install gcovr
+      - |
+        cmake \
+            -D CMAKE_BUILD_TYPE=Debug \
+            -D CMAKE_C_COMPILER=gcc-7 \
+            -D CMAKE_CXX_COMPILER=g++-7 \
+            -D CMAKE_C_COMPILER_LAUNCHER=ccache \
+            -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -D RESOURCE_POOL_BUILD_TESTS=ON \
+            -D RESOURCE_POOL_BUILD_EXAMPLES=ON \
+            -D RESOURCE_POOL_BUILD_BENCHMARKS=ON \
+            ${TRAVIS_BUILD_DIR}
+      - make -j $(nproc)
+      - ctest -V -j $(nproc)

--- a/include/yamail/resource_pool/async/detail/pool_impl.hpp
+++ b/include/yamail/resource_pool/async/detail/pool_impl.hpp
@@ -347,10 +347,14 @@ void pool_impl<V, M, I, Q>::perform_one_request(unique_lock& lock, Serve&& serve
 }
 
 using boost::asio::async_result;
+#if BOOST_VERSION < 106700
+using boost::asio::handler_type;
+#else
 template<typename CompletionToken, typename Signature>
 struct handler_type {
-    using type = typename boost::asio::async_result<CompletionToken, Signature>::completion_handler_type;
+    using type = typename ::boost::asio::async_result<CompletionToken, Signature>::completion_handler_type;
 };
+#endif
 
 #if BOOST_VERSION < 106600
 template <typename CompletionToken, typename Signature>
@@ -369,8 +373,15 @@ struct async_completion {
 using boost::asio::async_completion;
 #endif
 
+#if BOOST_VERSION < 106700
+template <typename Handler, typename Signature>
+using async_return_type = typename ::boost::asio::async_result<
+        typename handler_type<Handler, Signature>::type
+    >::type;
+#else
 template <typename Handler, typename Signature>
 using async_return_type = typename ::boost::asio::async_result<Handler, Signature>::return_type;
+#endif
 
 } // namespace detail
 } // namespace async

--- a/include/yamail/resource_pool/async/detail/pool_impl.hpp
+++ b/include/yamail/resource_pool/async/detail/pool_impl.hpp
@@ -347,7 +347,10 @@ void pool_impl<V, M, I, Q>::perform_one_request(unique_lock& lock, Serve&& serve
 }
 
 using boost::asio::async_result;
-using boost::asio::handler_type;
+template<typename CompletionToken, typename Signature>
+struct handler_type {
+    using type = typename boost::asio::async_result<CompletionToken, Signature>::completion_handler_type;
+};
 
 #if BOOST_VERSION < 106600
 template <typename CompletionToken, typename Signature>
@@ -367,9 +370,7 @@ using boost::asio::async_completion;
 #endif
 
 template <typename Handler, typename Signature>
-using async_return_type = typename ::boost::asio::async_result<
-        typename handler_type<Handler, Signature>::type
-    >::type;
+using async_return_type = typename ::boost::asio::async_result<Handler, Signature>::return_type;
 
 } // namespace detail
 } // namespace async

--- a/include/yamail/resource_pool/async/detail/queue.hpp
+++ b/include/yamail/resource_pool/async/detail/queue.hpp
@@ -6,6 +6,7 @@
 
 #include <boost/asio/executor.hpp>
 #include <boost/asio/post.hpp>
+#include <boost/noncopyable.hpp>
 
 #include <algorithm>
 #include <list>


### PR DESCRIPTION
Hi,

as per [ozo#132](https://github.com/yandex/ozo/issues/132) I'm trying to back-port my changes for 1.70 without being too intrusive.

The supplied code works (see https://travis-ci.org/JonasProgrammer/resource_pool/builds/535013854), the 1.70 version fails linking due to `coroutine` in travis, however.
On the other hand, the project I'm using ozo (and therefore resource_pool with the exact same code as this PR) in, builds and links fine with Boost 1.70. `resource_pool_test` runs fine as well.

I honestly have no idea why the standalone 1.70 fails, but perhaps you have and idea. 