### PR TITLE
 Support move-only user handler 

### DIFF
--- a/benchmarks/async.cc
+++ b/benchmarks/async.cc
@@ -71,7 +71,6 @@ struct context {
     boost::asio::executor_work_guard<boost::asio::io_context::executor_type> guard = boost::asio::make_work_guard(io_context);
     std::atomic_bool stop {false};
     time_traits::duration timeout {std::chrono::milliseconds(100)};
-    double recycle_probability {0};
     std::vector<std::chrono::steady_clock::duration> durations;
     std::mutex get_next_mutex;
     std::condition_variable get_next;

--- a/benchmarks/async.cc
+++ b/benchmarks/async.cc
@@ -64,7 +64,9 @@ private:
     std::size_t queue_size_ = 0;
 };
 
-struct resource {};
+struct resource {
+    std::int64_t value = 0;
+};
 
 struct context {
     boost::asio::io_context io_context;
@@ -114,6 +116,7 @@ struct callback {
             if (handle.empty()) {
                 handle.reset(resource {});
             }
+            benchmark::DoNotOptimize(++handle->value);
             if (distrubution(generator) < recycle_probability) {
                 handle.recycle();
             }
@@ -208,6 +211,7 @@ void get_auto_waste_io_context_per_thread_on_coroutines(benchmark::State& state)
                         if (handle.empty()) {
                             handle.reset(resource {});
                         }
+                        benchmark::DoNotOptimize(++handle->value);
                         if (distrubution(generator) < recycle_probability) {
                             handle.recycle();
                         }

--- a/include/yamail/resource_pool/async/detail/queue.hpp
+++ b/include/yamail/resource_pool/async/detail/queue.hpp
@@ -105,7 +105,7 @@ private:
     timers_map _timers;
 
     bool fit_capacity() const { return _expires_at_requests.size() < _capacity; }
-    void cancel(const boost::system::error_code& ec, time_traits::time_point expires_at);
+    void cancel(boost::system::error_code ec, time_traits::time_point expires_at);
     void update_timer();
     timer_t& get_timer(io_context_t& io_context);
 };
@@ -166,7 +166,7 @@ bool queue<V, M, I, T>::pop(io_context_t*& io_context, value_type& request) {
 }
 
 template <class V, class M, class I, class T>
-void queue<V, M, I, T>::cancel(const boost::system::error_code& ec, time_traits::time_point expires_at) {
+void queue<V, M, I, T>::cancel(boost::system::error_code ec, time_traits::time_point expires_at) {
     if (ec) {
         return;
     }
@@ -195,7 +195,7 @@ void queue<V, M, I, T>::update_timer() {
     auto& timer = get_timer(*earliest_expire->second->io_context);
     timer.expires_at(expires_at);
     std::weak_ptr<queue> weak(this->shared_from_this());
-    timer.async_wait([weak, expires_at] (const boost::system::error_code& ec) {
+    timer.async_wait([weak, expires_at] (boost::system::error_code ec) {
         if (const auto locked = weak.lock()) {
             locked->cancel(ec, expires_at);
         }

--- a/include/yamail/resource_pool/async/pool.hpp
+++ b/include/yamail/resource_pool/async/pool.hpp
@@ -130,7 +130,7 @@ private:
             static_assert(std::is_same<std::decay_t<HandlerT>, Handler>::value, "HandlerT is not Handler");
         }
 
-        void operator ()(const boost::system::error_code& ec, list_iterator res) {
+        void operator ()(boost::system::error_code ec, list_iterator res) {
             if (ec) {
                 handler(ec, handle());
             } else {

--- a/include/yamail/resource_pool/async/pool.hpp
+++ b/include/yamail/resource_pool/async/pool.hpp
@@ -19,7 +19,7 @@ struct default_pool_queue {
     using idle = resource_pool::detail::idle<value_type>;
     using list = std::list<idle>;
     using list_iterator = typename list::iterator;
-    using type = detail::queue<detail::queued_handler<list_iterator>, mutex_t, io_context_t, time_traits::timer>;
+    using type = detail::queue<detail::list_iterator_handler<list_iterator>, mutex_t, io_context_t, time_traits::timer>;
 };
 
 template <class Value, class Mutex, class IoContext>

--- a/include/yamail/resource_pool/async/pool.hpp
+++ b/include/yamail/resource_pool/async/pool.hpp
@@ -95,7 +95,7 @@ public:
     auto get_auto_waste(io_context_t& io_context, CompletionToken&& token,
                         time_traits::duration wait_duration = time_traits::duration(0)) {
         async_completion<CompletionToken> init(token);
-        get(io_context, init.completion_handler, &handle::waste, wait_duration);
+        get(io_context, std::move(init.completion_handler), &handle::waste, wait_duration);
         return init.result.get();
     }
 
@@ -103,7 +103,7 @@ public:
     auto get_auto_recycle(io_context_t& io_context, CompletionToken&& token,
                           time_traits::duration wait_duration = time_traits::duration(0)) {
         async_completion<CompletionToken> init(token);
-        get(io_context, init.completion_handler, &handle::recycle, wait_duration);
+        get(io_context, std::move(init.completion_handler), &handle::recycle, wait_duration);
         return init.result.get();
     }
 
@@ -122,10 +122,13 @@ private:
     public:
         using executor_type = std::decay_t<decltype(asio::get_associated_executor(handler))>;
 
-        on_get_handler(std::shared_ptr<pool_impl> impl, UseStrategy use_strategy, Handler handler)
+        template <class HandlerT>
+        on_get_handler(std::shared_ptr<pool_impl> impl, UseStrategy use_strategy, HandlerT&& handler)
             : impl(std::move(impl)),
               use_strategy(std::move(use_strategy)),
-              handler(std::move(handler)) {}
+              handler(std::forward<HandlerT>(handler)) {
+            static_assert(std::is_same<std::decay_t<HandlerT>, Handler>::value, "HandlerT is not Handler");
+        }
 
         void operator ()(const boost::system::error_code& ec, list_iterator res) {
             if (ec) {

--- a/scripts/travis/conan.sh
+++ b/scripts/travis/conan.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 pip install --user virtualenv
 virtualenv conan-temp
@@ -6,11 +6,16 @@ virtualenv conan-temp
 pip install conan
 conan profile new --detect default
 
+export CC=/usr/bin/clang-8
+export CXX=/usr/bin/clang++-8
+
+conan profile update settings.compiler=clang default
+conan profile update settings.compiler.version=8 default
+conan profile update settings.compiler.libcxx=libstdc++11 default
+
 cd "${TRAVIS_BUILD_DIR}"
 
 PKG_REPO="elsid/testing"
-
-
 conan export . "${PKG_REPO}"
 
 PKG_NAME="$(conan inspect --raw name .)/$(conan inspect --raw version .)"

--- a/tests/async/integration.cc
+++ b/tests/async/integration.cc
@@ -31,14 +31,14 @@ using boost::system::error_code;
 
 struct async_resource_pool_integration : Test {
     asio::io_context io;
-    std::atomic_flag coroutine_finished {};
-    std::atomic_flag coroutine1_finished {};
-    std::atomic_flag coroutine2_finished {};
-    std::atomic_flag coroutine3_finished {};
-    std::atomic_flag on_get_called {};
-    std::atomic_flag on_get1_called {};
-    std::atomic_flag on_get2_called {};
-    std::atomic_flag on_get3_called {};
+    std::atomic_flag coroutine_finished = ATOMIC_FLAG_INIT;
+    std::atomic_flag coroutine1_finished = ATOMIC_FLAG_INIT;
+    std::atomic_flag coroutine2_finished = ATOMIC_FLAG_INIT;
+    std::atomic_flag coroutine3_finished = ATOMIC_FLAG_INIT;
+    std::atomic_flag on_get_called = ATOMIC_FLAG_INIT;
+    std::atomic_flag on_get1_called = ATOMIC_FLAG_INIT;
+    std::atomic_flag on_get2_called = ATOMIC_FLAG_INIT;
+    std::atomic_flag on_get3_called = ATOMIC_FLAG_INIT;
 };
 
 TEST_F(async_resource_pool_integration, first_get_auto_recycle_should_return_usable_empty_handle_to_resource) {


### PR DESCRIPTION
Instead of having two copies of user handler in a queue only one is stored. A new handler type `list_iterator_handler` is introduced as a replacement for `std::function` that doesn't support move-only functions.