### PR TITLE
Make handle independent from the pool type

### DIFF
--- a/include/yamail/resource_pool/async/detail/pool_impl.hpp
+++ b/include/yamail/resource_pool/async/detail/pool_impl.hpp
@@ -4,6 +4,7 @@
 #include <yamail/resource_pool/error.hpp>
 #include <yamail/resource_pool/detail/idle.hpp>
 #include <yamail/resource_pool/detail/storage.hpp>
+#include <yamail/resource_pool/detail/pool_returns.hpp>
 #include <yamail/resource_pool/async/detail/queue.hpp>
 
 #include <boost/asio/dispatch.hpp>
@@ -30,6 +31,7 @@ namespace asio = boost::asio;
 
 using resource_pool::detail::cell_iterator;
 using resource_pool::detail::cell_value;
+using resource_pool::detail::pool_returns;
 
 template <class T, class Handler>
 class on_list_iterator_handler {
@@ -185,7 +187,7 @@ on_serve_queued_handler(ListIterator, Handler&&)
     -> on_serve_queued_handler<cell_value<ListIterator>, std::decay_t<Handler>>;
 
 template <class Value, class Mutex, class IoContext, class Queue>
-class pool_impl {
+class pool_impl : public pool_returns<Value> {
 public:
     using value_type = Value;
     using io_context_t = IoContext;
@@ -236,8 +238,8 @@ public:
 
     template <class Handler>
     void get(io_context_t& io_context, Handler&& handler, time_traits::duration wait_duration = time_traits::duration(0));
-    void recycle(list_iterator res_it);
-    void waste(list_iterator res_it);
+    void recycle(list_iterator res_it) final;
+    void waste(list_iterator res_it) final;
     void disable();
 
     static std::size_t assert_capacity(std::size_t value);

--- a/include/yamail/resource_pool/async/pool.hpp
+++ b/include/yamail/resource_pool/async/pool.hpp
@@ -41,7 +41,7 @@ public:
     using value_type = Value;
     using io_context_t = IoContext;
     using pool_impl = Impl;
-    using handle = resource_pool::handle<pool_impl>;
+    using handle = resource_pool::handle<value_type>;
 
     pool(std::size_t capacity,
          std::size_t queue_capacity,
@@ -70,6 +70,9 @@ public:
                 first, last,
                 queue_capacity,
                 idle_timeout)) {}
+
+    pool(std::shared_ptr<pool_impl> impl)
+            : _impl(std::move(impl)) {}
 
     pool(const pool&) = delete;
     pool(pool&&) = default;

--- a/include/yamail/resource_pool/async/pool.hpp
+++ b/include/yamail/resource_pool/async/pool.hpp
@@ -19,7 +19,7 @@ struct default_pool_queue {
     using idle = resource_pool::detail::idle<value_type>;
     using list = std::list<idle>;
     using list_iterator = typename list::iterator;
-    using type = detail::queue<detail::list_iterator_handler<list_iterator>, mutex_t, io_context_t, time_traits::timer>;
+    using type = detail::queue<detail::list_iterator_handler<value_type>, mutex_t, io_context_t, time_traits::timer>;
 };
 
 template <class Value, class Mutex, class IoContext>

--- a/include/yamail/resource_pool/detail/pool_returns.hpp
+++ b/include/yamail/resource_pool/detail/pool_returns.hpp
@@ -1,0 +1,23 @@
+#ifndef YAMAIL_RESOURCE_POOL_DETAIL_POOL_RETURNS_HPP
+#define YAMAIL_RESOURCE_POOL_DETAIL_POOL_RETURNS_HPP
+
+#include <yamail/resource_pool/detail/storage.hpp>
+
+namespace yamail {
+namespace resource_pool {
+namespace detail {
+
+template <class T>
+struct pool_returns {
+    virtual ~pool_returns() = default;
+
+    virtual void waste(cell_iterator<T> resource_iterator) = 0;
+
+    virtual void recycle(cell_iterator<T> resource_iterator) = 0;
+};
+
+} // namespace detail
+} // namespace resource_pool
+} // namespace yamail
+
+#endif

--- a/include/yamail/resource_pool/detail/storage.hpp
+++ b/include/yamail/resource_pool/detail/storage.hpp
@@ -50,6 +50,12 @@ private:
 };
 
 template <class T>
+using cell_iterator = typename storage<T>::cell_iterator;
+
+template <class CellIterator>
+using cell_value = typename CellIterator::value_type::value_type;
+
+template <class T>
 storage<T>::storage(std::size_t capacity, time_traits::duration idle_timeout)
         : idle_timeout_(idle_timeout),
           wasted_(capacity) {

--- a/include/yamail/resource_pool/sync/detail/pool_impl.hpp
+++ b/include/yamail/resource_pool/sync/detail/pool_impl.hpp
@@ -5,6 +5,7 @@
 #include <yamail/resource_pool/time_traits.hpp>
 #include <yamail/resource_pool/detail/idle.hpp>
 #include <yamail/resource_pool/detail/storage.hpp>
+#include <yamail/resource_pool/detail/pool_returns.hpp>
 
 #include <condition_variable>
 #include <list>
@@ -22,8 +23,10 @@ struct stats {
 
 namespace detail {
 
+using resource_pool::detail::pool_returns;
+
 template <class Value, class Mutex, class ConditionVariable>
-class pool_impl {
+class pool_impl : public pool_returns<Value> {
 public:
     using value_type = Value;
     using condition_variable = ConditionVariable;
@@ -47,8 +50,8 @@ public:
     const condition_variable& has_capacity() const { return _has_capacity; }
 
     get_result get(time_traits::duration wait_duration = time_traits::duration(0));
-    void recycle(list_iterator res_it);
-    void waste(list_iterator res_it);
+    void recycle(list_iterator res_it) final;
+    void waste(list_iterator res_it) final;
     void disable();
 
     static std::size_t assert_capacity(std::size_t value);

--- a/include/yamail/resource_pool/sync/pool.hpp
+++ b/include/yamail/resource_pool/sync/pool.hpp
@@ -18,11 +18,15 @@ class pool {
 public:
     using value_type = Value;
     using pool_impl = Impl;
-    using handle = resource_pool::handle<pool_impl>;
+    using handle = resource_pool::handle<value_type>;
     using get_result = std::pair<boost::system::error_code, handle>;
 
     pool(std::size_t capacity, time_traits::duration idle_timeout = time_traits::duration::max())
             : _impl(std::make_shared<pool_impl>(capacity, idle_timeout))
+    {}
+
+    pool(std::shared_ptr<pool_impl> impl)
+            : _impl(std::move(impl))
     {}
 
     pool(const pool&) = delete;
@@ -42,8 +46,6 @@ public:
     std::size_t available() const { return _impl->available(); }
     std::size_t used() const { return _impl->used(); }
     sync::stats stats() const { return _impl->stats(); }
-
-    const pool_impl& impl() const { return *_impl; }
 
     get_result get_auto_waste(time_traits::duration wait_duration = time_traits::duration(0)) {
         return get_handle(&handle::waste, wait_duration);

--- a/tests/async/pool_impl.cc
+++ b/tests/async/pool_impl.cc
@@ -10,7 +10,7 @@ using namespace yamail::resource_pool::async::detail;
 
 struct mocked_queue {
     using list_iterator = std::list<detail::idle<resource>>::iterator;
-    using value_type = list_iterator_handler<list_iterator>;
+    using value_type = list_iterator_handler<resource>;
     using queued_value_t = queued_value<value_type, mocked_io_context>;
 
     MOCK_CONST_METHOD3(push, bool (mocked_io_context&, time_traits::duration, const value_type&));

--- a/tests/sync/pool.cc
+++ b/tests/sync/pool.cc
@@ -17,27 +17,27 @@ struct resource {
     resource& operator =(resource&&) = default;
 };
 
-struct mocked_pool_impl {
+using yamail::resource_pool::detail::pool_returns;
+
+struct mocked_pool_impl : pool_returns<resource> {
     using value_type = resource;
     using idle = yamail::resource_pool::detail::idle<value_type>;
     using list = std::list<idle>;
     using list_iterator = list::iterator;
     using get_result = std::pair<boost::system::error_code, list_iterator>;
 
-    mocked_pool_impl(std::size_t, time_traits::duration) {}
-
     MOCK_CONST_METHOD0(capacity, std::size_t ());
     MOCK_CONST_METHOD0(size, std::size_t ());
     MOCK_CONST_METHOD0(available, std::size_t ());
     MOCK_CONST_METHOD0(used, std::size_t ());
     MOCK_CONST_METHOD0(stats, sync::stats ());
-    MOCK_CONST_METHOD1(get, get_result (time_traits::duration));
-    MOCK_CONST_METHOD1(recycle, void (list_iterator));
-    MOCK_CONST_METHOD1(waste, void (list_iterator));
-    MOCK_CONST_METHOD0(disable, void ());
+    MOCK_METHOD1(get, get_result (time_traits::duration));
+    MOCK_METHOD1(recycle, void (list_iterator));
+    MOCK_METHOD1(waste, void (list_iterator));
+    MOCK_METHOD0(disable, void ());
 };
 
-using resource_pool = pool<resource, std::mutex, mocked_pool_impl>;
+using resource_pool = pool<resource, std::mutex, StrictMock<mocked_pool_impl>>;
 
 struct sync_resource_pool : Test {
     mocked_pool_impl::list resources;
@@ -52,78 +52,85 @@ TEST_F(sync_resource_pool, create_without_mocks_should_succeed) {
 }
 
 TEST_F(sync_resource_pool, call_capacity_should_call_impl_capacity) {
-    const resource_pool pool(1);
+    const auto pool_impl = std::make_shared<StrictMock<mocked_pool_impl>>();
+    const resource_pool pool(pool_impl);
 
     InSequence s;
 
-    EXPECT_CALL(pool.impl(), capacity()).WillOnce(Return(0));
-    EXPECT_CALL(pool.impl(), disable()).WillOnce(Return());
+    EXPECT_CALL(*pool_impl, capacity()).WillOnce(Return(0));
+    EXPECT_CALL(*pool_impl, disable()).WillOnce(Return());
 
     pool.capacity();
 }
 
 TEST_F(sync_resource_pool, call_size_should_call_impl_size) {
-    const resource_pool pool(1);
+    const auto pool_impl = std::make_shared<StrictMock<mocked_pool_impl>>();
+    const resource_pool pool(pool_impl);
 
     InSequence s;
 
-    EXPECT_CALL(pool.impl(), size()).WillOnce(Return(0));
-    EXPECT_CALL(pool.impl(), disable()).WillOnce(Return());
+    EXPECT_CALL(*pool_impl, size()).WillOnce(Return(0));
+    EXPECT_CALL(*pool_impl, disable()).WillOnce(Return());
 
     pool.size();
 }
 
 TEST_F(sync_resource_pool, call_available_should_call_impl_available) {
-    const resource_pool pool(1);
+    const auto pool_impl = std::make_shared<StrictMock<mocked_pool_impl>>();
+    const resource_pool pool(pool_impl);
 
     InSequence s;
 
-    EXPECT_CALL(pool.impl(), available()).WillOnce(Return(0));
-    EXPECT_CALL(pool.impl(), disable()).WillOnce(Return());
+    EXPECT_CALL(*pool_impl, available()).WillOnce(Return(0));
+    EXPECT_CALL(*pool_impl, disable()).WillOnce(Return());
 
     pool.available();
 }
 
 TEST_F(sync_resource_pool, call_used_should_call_impl_used) {
-    const resource_pool pool(1);
+    const auto pool_impl = std::make_shared<StrictMock<mocked_pool_impl>>();
+    const resource_pool pool(pool_impl);
 
     InSequence s;
 
-    EXPECT_CALL(pool.impl(), used()).WillOnce(Return(0));
-    EXPECT_CALL(pool.impl(), disable()).WillOnce(Return());
+    EXPECT_CALL(*pool_impl, used()).WillOnce(Return(0));
+    EXPECT_CALL(*pool_impl, disable()).WillOnce(Return());
 
     pool.used();
 }
 
 TEST_F(sync_resource_pool, call_stats_should_call_impl_stats) {
-    const resource_pool pool(1);
+    const auto pool_impl = std::make_shared<StrictMock<mocked_pool_impl>>();
+    const resource_pool pool(pool_impl);
 
     InSequence s;
 
-    EXPECT_CALL(pool.impl(), stats()).WillOnce(Return(sync::stats {0, 0, 0}));
-    EXPECT_CALL(pool.impl(), disable()).WillOnce(Return());
+    EXPECT_CALL(*pool_impl, stats()).WillOnce(Return(sync::stats {0, 0, 0}));
+    EXPECT_CALL(*pool_impl, disable()).WillOnce(Return());
 
     pool.stats();
 }
 
 TEST_F(sync_resource_pool, move_than_dtor_should_call_disable_only_for_destination) {
-    resource_pool src(1);
+    const auto pool_impl = std::make_shared<StrictMock<mocked_pool_impl>>();
+    resource_pool src(pool_impl);
 
-    EXPECT_CALL(src.impl(), disable()).Times(0);
+    EXPECT_CALL(*pool_impl, disable()).Times(0);
 
     const auto dst = std::move(src);
 
-    EXPECT_CALL(dst.impl(), disable()).WillOnce(Return());
+    EXPECT_CALL(*pool_impl, disable()).WillOnce(Return());
 }
 
 TEST_F(sync_resource_pool, get_auto_recylce_handle_should_call_recycle) {
-    resource_pool pool(1);
+    const auto pool_impl = std::make_shared<StrictMock<mocked_pool_impl>>();
+    resource_pool pool(pool_impl);
 
     InSequence s;
 
-    EXPECT_CALL(pool.impl(), get(_)).WillOnce(Return(mocked_pool_impl::get_result(boost::system::error_code(), resource_iterator)));
-    EXPECT_CALL(pool.impl(), recycle(_)).WillOnce(Return());
-    EXPECT_CALL(pool.impl(), disable()).WillOnce(Return());
+    EXPECT_CALL(*pool_impl, get(_)).WillOnce(Return(mocked_pool_impl::get_result(boost::system::error_code(), resource_iterator)));
+    EXPECT_CALL(*pool_impl, recycle(_)).WillOnce(Return());
+    EXPECT_CALL(*pool_impl, disable()).WillOnce(Return());
 
     auto res = pool.get_auto_recycle();
     auto& ec = res.first;
@@ -137,13 +144,14 @@ TEST_F(sync_resource_pool, get_auto_recylce_handle_should_call_recycle) {
 }
 
 TEST_F(sync_resource_pool, get_auto_waste_handle_should_call_waste) {
-    resource_pool pool(1);
+    const auto pool_impl = std::make_shared<StrictMock<mocked_pool_impl>>();
+    resource_pool pool(pool_impl);
 
     InSequence s;
 
-    EXPECT_CALL(pool.impl(), get(_)).WillOnce(Return(mocked_pool_impl::get_result(boost::system::error_code(), resource_iterator)));
-    EXPECT_CALL(pool.impl(), waste(_)).WillOnce(Return());
-    EXPECT_CALL(pool.impl(), disable()).WillOnce(Return());
+    EXPECT_CALL(*pool_impl, get(_)).WillOnce(Return(mocked_pool_impl::get_result(boost::system::error_code(), resource_iterator)));
+    EXPECT_CALL(*pool_impl, waste(_)).WillOnce(Return());
+    EXPECT_CALL(*pool_impl, disable()).WillOnce(Return());
 
     const auto res = pool.get_auto_waste();
     const auto& handle = res.second;
@@ -152,13 +160,14 @@ TEST_F(sync_resource_pool, get_auto_waste_handle_should_call_waste) {
 }
 
 TEST_F(sync_resource_pool, get_auto_recylce_handle_and_recycle_should_call_recycle_once) {
-    resource_pool pool(1);
+    const auto pool_impl = std::make_shared<StrictMock<mocked_pool_impl>>();
+    resource_pool pool(pool_impl);
 
     InSequence s;
 
-    EXPECT_CALL(pool.impl(), get(_)).WillOnce(Return(mocked_pool_impl::get_result(boost::system::error_code(), resource_iterator)));
-    EXPECT_CALL(pool.impl(), recycle(_)).WillOnce(Return());
-    EXPECT_CALL(pool.impl(), disable()).WillOnce(Return());
+    EXPECT_CALL(*pool_impl, get(_)).WillOnce(Return(mocked_pool_impl::get_result(boost::system::error_code(), resource_iterator)));
+    EXPECT_CALL(*pool_impl, recycle(_)).WillOnce(Return());
+    EXPECT_CALL(*pool_impl, disable()).WillOnce(Return());
 
     auto res = pool.get_auto_recycle();
     auto& handle = res.second;
@@ -172,13 +181,14 @@ TEST_F(sync_resource_pool, get_auto_recylce_handle_and_recycle_should_call_recyc
 }
 
 TEST_F(sync_resource_pool, get_auto_recylce_handle_and_waste_should_call_waste_once) {
-    resource_pool pool(1);
+    const auto pool_impl = std::make_shared<StrictMock<mocked_pool_impl>>();
+    resource_pool pool(pool_impl);
 
     InSequence s;
 
-    EXPECT_CALL(pool.impl(), get(_)).WillOnce(Return(mocked_pool_impl::get_result(boost::system::error_code(), resource_iterator)));
-    EXPECT_CALL(pool.impl(), waste(_)).WillOnce(Return());
-    EXPECT_CALL(pool.impl(), disable()).WillOnce(Return());
+    EXPECT_CALL(*pool_impl, get(_)).WillOnce(Return(mocked_pool_impl::get_result(boost::system::error_code(), resource_iterator)));
+    EXPECT_CALL(*pool_impl, waste(_)).WillOnce(Return());
+    EXPECT_CALL(*pool_impl, disable()).WillOnce(Return());
 
     auto res = pool.get_auto_recycle();
     auto& handle = res.second;
@@ -187,13 +197,14 @@ TEST_F(sync_resource_pool, get_auto_recylce_handle_and_waste_should_call_waste_o
 }
 
 TEST_F(sync_resource_pool, get_auto_waste_handle_and_recycle_should_call_recycle_once) {
-    resource_pool pool(1);
+    const auto pool_impl = std::make_shared<StrictMock<mocked_pool_impl>>();
+    resource_pool pool(pool_impl);
 
     InSequence s;
 
-    EXPECT_CALL(pool.impl(), get(_)).WillOnce(Return(mocked_pool_impl::get_result(boost::system::error_code(), resource_iterator)));
-    EXPECT_CALL(pool.impl(), recycle(_)).WillOnce(Return());
-    EXPECT_CALL(pool.impl(), disable()).WillOnce(Return());
+    EXPECT_CALL(*pool_impl, get(_)).WillOnce(Return(mocked_pool_impl::get_result(boost::system::error_code(), resource_iterator)));
+    EXPECT_CALL(*pool_impl, recycle(_)).WillOnce(Return());
+    EXPECT_CALL(*pool_impl, disable()).WillOnce(Return());
 
     auto res = pool.get_auto_waste();
     auto& handle = res.second;
@@ -202,13 +213,14 @@ TEST_F(sync_resource_pool, get_auto_waste_handle_and_recycle_should_call_recycle
 }
 
 TEST_F(sync_resource_pool, get_auto_waste_handle_and_waste_should_call_waste_once) {
-    resource_pool pool(1);
+    const auto pool_impl = std::make_shared<StrictMock<mocked_pool_impl>>();
+    resource_pool pool(pool_impl);
 
     InSequence s;
 
-    EXPECT_CALL(pool.impl(), get(_)).WillOnce(Return(mocked_pool_impl::get_result(boost::system::error_code(), resource_iterator)));
-    EXPECT_CALL(pool.impl(), waste(_)).WillOnce(Return());
-    EXPECT_CALL(pool.impl(), disable()).WillOnce(Return());
+    EXPECT_CALL(*pool_impl, get(_)).WillOnce(Return(mocked_pool_impl::get_result(boost::system::error_code(), resource_iterator)));
+    EXPECT_CALL(*pool_impl, waste(_)).WillOnce(Return());
+    EXPECT_CALL(*pool_impl, disable()).WillOnce(Return());
 
     auto res = pool.get_auto_waste();
     auto& handle = res.second;


### PR DESCRIPTION
Now to define a handle type client need to know a pool type:
```cpp
using pool_t = yamail::resource_pool::pool<my_resource>;
using handle_t1 = yamail::resource_pool::handle<pool_t>;
// or
using handle_t2 = pool_t::handle;
```

This pr allows to simplify client code and decouple pool type and handle type definitions:
```cpp
using pool_t = yamail::resource_pool::pool<my_resource>;
using handle = yamail::resource_pool::handle<my_resource>;
```

It becomes possible through introduction of a new interface `pool_returns`. 