### PR TITLE
Fix compiler warning

### DIFF
--- a/include/yamail/resource_pool/async/detail/queue.hpp
+++ b/include/yamail/resource_pool/async/detail/queue.hpp
@@ -168,7 +168,7 @@ boost::optional<typename queue<V, M, I, T>::queued_value_t> queue<V, M, I, T>::p
     _expires_at_requests.erase(req.expires_at_it);
     _ordered_requests_pool.splice(_ordered_requests_pool.begin(), _ordered_requests, ordered_it);
     update_timer();
-    return result;
+    return { std::move(result) };
 }
 
 template <class V, class M, class I, class T>


### PR DESCRIPTION
> /home/jonesmz/meshpp_frameworks/3rdparty/ozo/contrib/resource_pool/include/yamail/resource_pool/async/detail/queue.hpp:171: warning: prior to the resolution of a defect report against ISO C++11, local variable 'result' would have been copied despite being returned by name, due to its not matching the function return type ('boost::optional<queued_value_t>' (aka 'optional<queued_value<yamail::resource_pool::async::detail::list_iterator_handler<std::_List_iterator<yamail::resource_pool::detail::idle<std::shared_ptr<ozo::connection<ozo::oid_map_t<boost::hana::detail::map_impl<boost::hana::detail::hash_table<>, boost::hana::basic_tuple<> > >, boost::hana::detail::map_impl<boost::hana::detail::hash_table<>, boost::hana::basic_tuple<> > > > > > >, boost::asio::io_context> >') vs 'yamail::resource_pool::async::detail::queue<yamail::resource_pool::async::detail::list_iterator_handler<std::_List_iterator<yamail::resource_pool::detail::idle<std::shared_ptr<ozo::connection<ozo::oid_map_t<boost::hana::detail::map_impl<boost::hana::detail::hash_table<>, boost::hana::basic_tuple<> > >, boost::hana::detail::map_impl<boost::hana::detail::hash_table<>, boost::hana::basic_tuple<> > > > > > >, std::mutex, boost::asio::io_context, boost::asio::basic_waitable_timer<std::chrono::_V2::steady_clock, boost::asio::wait_traits<std::chrono::_V2::steady_clock>, boost::asio::executor> >::queued_value_t' (aka 'queued_value<yamail::resource_pool::async::detail::list_iterator_handler<std::_List_iterator<yamail::resource_pool::detail::idle<std::shared_ptr<ozo::connection<ozo::oid_map_t<boost::hana::detail::map_impl<boost::hana::detail::hash_table<>, boost::hana::basic_tuple<> > >, boost::hana::detail::map_impl<boost::hana::detail::hash_table<>, boost::hana::basic_tuple<> > > > > > >, boost::asio::io_context>')) [-Wreturn-std-move-in-c++11]
>     return result;
>            ^~~~~~



The problem is that "result" is of type queued_value_t, and the function is returning boost::optional<queued_value_t>.