### PR TITLE
Support resource lifespan

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,19 @@ Example:
 using fstream_pool = pool<std::fstream>;
 ```
 
-Object constructing requires capacity of pool:
+Object construction requires pool capacity:
 ```c++
 pool(
     std::size_t capacity,
-    time_traits::duration idle_timeout = time_traits::duration::max()
+    time_traits::duration idle_timeout = time_traits::duration::max(),
+    time_traits::duration lifespan = time_traits::duration::max()
 );
 ```
+
+* `idle_timeout` defines maximum time interval to keep unused resource in the pool.
+  Check for elapsed time happens on resource allocation.
+* `lifespan` defines maximum time interval to keep resource.
+  Check for elapsed time happens on resource allocation and recycle.
 
 Example:
 ```c++
@@ -168,15 +174,21 @@ Example:
 using fstream_pool = pool<std::fstream>;
 ```
 
-Object constructing requires reference to io service, capacity of pool, queue capacity:
+Object construction requires reference to io service, capacity of pool, queue capacity:
 ```c++
 pool(
     io_context_t& io_context,
     std::size_t capacity,
     std::size_t queue_capacity,
-    time_traits::duration idle_timeout = time_traits::duration::max()
+    time_traits::duration idle_timeout = time_traits::duration::max(),
+    time_traits::duration lifespan = time_traits::duration::max()
 );
 ```
+
+* `idle_timeout` defines maximum time interval to keep unused resource in the pool.
+  Check for elapsed time happens on resource allocation.
+* `lifespan` defines maximum time interval to keep resource.
+  Check for elapsed time happens on resource allocation and recycle.
 
 Example:
 ```c++

--- a/include/yamail/resource_pool/async/detail/pool_impl.hpp
+++ b/include/yamail/resource_pool/async/detail/pool_impl.hpp
@@ -198,8 +198,9 @@ public:
 
     pool_impl(std::size_t capacity,
               std::size_t queue_capacity,
-              time_traits::duration idle_timeout)
-            : storage_(assert_capacity(capacity), idle_timeout),
+              time_traits::duration idle_timeout,
+              time_traits::duration lifespan)
+            : storage_(assert_capacity(capacity), idle_timeout, lifespan),
               _capacity(capacity),
               _callbacks(std::make_shared<queue_type>(queue_capacity)) {
     }
@@ -208,8 +209,9 @@ public:
     pool_impl(Generator&& gen_value,
               std::size_t capacity,
               std::size_t queue_capacity,
-              time_traits::duration idle_timeout)
-            : storage_(std::forward<Generator>(gen_value), assert_capacity(capacity), idle_timeout),
+              time_traits::duration idle_timeout,
+              time_traits::duration lifespan)
+            : storage_(std::forward<Generator>(gen_value), assert_capacity(capacity), idle_timeout, lifespan),
               _capacity(assert_capacity(capacity)),
               _callbacks(std::make_shared<queue_type>(queue_capacity)) {
     }
@@ -217,11 +219,13 @@ public:
     template <class Iter>
     pool_impl(Iter first, Iter last,
               std::size_t queue_capacity,
-              time_traits::duration idle_timeout)
+              time_traits::duration idle_timeout,
+              time_traits::duration lifespan)
             : pool_impl([&]{ return std::move(*first++); },
                     static_cast<std::size_t>(std::distance(first, last)),
                     queue_capacity,
-                    idle_timeout) {
+                    idle_timeout,
+                    lifespan) {
     }
 
     pool_impl(const pool_impl&) = delete;

--- a/include/yamail/resource_pool/async/pool.hpp
+++ b/include/yamail/resource_pool/async/pool.hpp
@@ -45,31 +45,37 @@ public:
 
     pool(std::size_t capacity,
          std::size_t queue_capacity,
-         time_traits::duration idle_timeout = time_traits::duration::max())
+         time_traits::duration idle_timeout = time_traits::duration::max(),
+         time_traits::duration lifespan = time_traits::duration::max())
             : _impl(std::make_shared<pool_impl>(
                 capacity,
                 queue_capacity,
-                idle_timeout)) {}
+                idle_timeout,
+                lifespan)) {}
 
     template <class Generator>
     pool(Generator&& gen_value,
          std::size_t capacity,
          std::size_t queue_capacity,
-         time_traits::duration idle_timeout = time_traits::duration::max())
+         time_traits::duration idle_timeout = time_traits::duration::max(),
+         time_traits::duration lifespan = time_traits::duration::max())
             : _impl(std::make_shared<pool_impl>(
                 std::forward<Generator>(gen_value),
                 capacity,
                 queue_capacity,
-                idle_timeout)) {}
+                idle_timeout,
+                lifespan)) {}
 
     template <class Iter>
     pool(Iter first, Iter last,
          std::size_t queue_capacity,
-         time_traits::duration idle_timeout = time_traits::duration::max())
+         time_traits::duration idle_timeout = time_traits::duration::max(),
+         time_traits::duration lifespan = time_traits::duration::max())
             : _impl(std::make_shared<pool_impl>(
                 first, last,
                 queue_capacity,
-                idle_timeout)) {}
+                idle_timeout,
+                lifespan)) {}
 
     pool(std::shared_ptr<pool_impl> impl)
             : _impl(std::move(impl)) {}

--- a/include/yamail/resource_pool/detail/idle.hpp
+++ b/include/yamail/resource_pool/detail/idle.hpp
@@ -15,11 +15,12 @@ struct idle {
 
     boost::optional<value_type> value;
     time_traits::time_point drop_time;
+    time_traits::time_point reset_time;
 
     idle(time_traits::time_point drop_time = time_traits::time_point::max())
         : drop_time(drop_time) {}
-    idle(value_type&& value, time_traits::time_point drop_time)
-        : value(std::move(value)), drop_time(drop_time) {}
+    idle(value_type&& value, time_traits::time_point drop_time, time_traits::time_point reset_time)
+        : value(std::move(value)), drop_time(drop_time), reset_time(reset_time) {}
 };
 
 } // namespace detail

--- a/include/yamail/resource_pool/handle.hpp
+++ b/include/yamail/resource_pool/handle.hpp
@@ -116,6 +116,7 @@ template <class P>
 void handle<P>::reset(value_type &&res) {
     assert_not_unusable();
     _resource_it.get()->value = std::move(res);
+    _resource_it.get()->reset_time = time_traits::now();
 }
 
 template <class P>

--- a/include/yamail/resource_pool/sync/detail/pool_impl.hpp
+++ b/include/yamail/resource_pool/sync/detail/pool_impl.hpp
@@ -35,8 +35,8 @@ public:
     using list_iterator = typename storage_type::cell_iterator;
     using get_result = std::pair<boost::system::error_code, list_iterator>;
 
-    pool_impl(std::size_t capacity, time_traits::duration idle_timeout)
-            : storage_(assert_capacity(capacity), idle_timeout),
+    pool_impl(std::size_t capacity, time_traits::duration idle_timeout, time_traits::duration lifespan)
+            : storage_(assert_capacity(capacity), idle_timeout, lifespan),
               _capacity(capacity),
               _disabled(false) {
     }

--- a/include/yamail/resource_pool/sync/pool.hpp
+++ b/include/yamail/resource_pool/sync/pool.hpp
@@ -21,8 +21,10 @@ public:
     using handle = resource_pool::handle<value_type>;
     using get_result = std::pair<boost::system::error_code, handle>;
 
-    pool(std::size_t capacity, time_traits::duration idle_timeout = time_traits::duration::max())
-            : _impl(std::make_shared<pool_impl>(capacity, idle_timeout))
+    pool(std::size_t capacity,
+         time_traits::duration idle_timeout = time_traits::duration::max(),
+         time_traits::duration lifespan = time_traits::duration::max())
+            : _impl(std::make_shared<pool_impl>(capacity, idle_timeout, lifespan))
     {}
 
     pool(std::shared_ptr<pool_impl> impl)

--- a/tests/async/pool_impl.cc
+++ b/tests/async/pool_impl.cc
@@ -61,27 +61,27 @@ struct async_resource_pool_impl : Test {
 };
 
 TEST_F(async_resource_pool_impl, create_with_zero_capacity_should_throw_exception) {
-    EXPECT_THROW(resource_pool_impl(0, 0, time_traits::duration::max()),
+    EXPECT_THROW(resource_pool_impl(0, 0, time_traits::duration::max(), time_traits::duration::max()),
                  error::zero_pool_capacity);
 }
 
 TEST_F(async_resource_pool_impl, create_const_with_non_zero_capacity_then_check) {
-    const resource_pool_impl pool(1, 0, time_traits::duration::max());
+    const resource_pool_impl pool(1, 0, time_traits::duration::max(), time_traits::duration::max());
     EXPECT_EQ(pool.capacity(), 1u);
 }
 
 TEST_F(async_resource_pool_impl, create_const_then_check_size_should_be_0) {
-    const resource_pool_impl pool(1, 0, time_traits::duration::max());
+    const resource_pool_impl pool(1, 0, time_traits::duration::max(), time_traits::duration::max());
     EXPECT_EQ(pool.size(), 0u);
 }
 
 TEST_F(async_resource_pool_impl, create_const_then_check_available_should_be_0) {
-    const resource_pool_impl pool(1, 0, time_traits::duration::max());
+    const resource_pool_impl pool(1, 0, time_traits::duration::max(), time_traits::duration::max());
     EXPECT_EQ(pool.available(), 0u);
 }
 
 TEST_F(async_resource_pool_impl, create_const_then_check_used_should_be_0) {
-    const resource_pool_impl pool(1, 0, time_traits::duration::max());
+    const resource_pool_impl pool(1, 0, time_traits::duration::max(), time_traits::duration::max());
     EXPECT_EQ(pool.used(), 0u);
 }
 
@@ -91,7 +91,7 @@ TEST_F(async_resource_pool_impl, create_const_with_range_len2_then_check_capacit
     res.emplace_back();
     const resource_pool_impl pool(
         std::make_move_iterator(std::begin(res)), std::make_move_iterator(std::end(res)),
-        0, time_traits::duration::max());
+        0, time_traits::duration::max(), time_traits::duration::max());
 
     EXPECT_EQ(pool.capacity(), 2u);
 }
@@ -102,7 +102,7 @@ TEST_F(async_resource_pool_impl, create_const_with_range_len2_then_check_size_sh
     res.emplace_back();
     const resource_pool_impl pool(
         std::make_move_iterator(std::begin(res)), std::make_move_iterator(std::end(res)),
-        0, time_traits::duration::max());
+        0, time_traits::duration::max(), time_traits::duration::max());
 
     EXPECT_EQ(pool.size(), 2u);
 }
@@ -113,32 +113,32 @@ TEST_F(async_resource_pool_impl, create_const_with_range_len2_then_check_availab
     res.emplace_back();
     const resource_pool_impl pool(
         std::make_move_iterator(std::begin(res)), std::make_move_iterator(std::end(res)),
-        0, time_traits::duration::max());
+        0, time_traits::duration::max(), time_traits::duration::max());
 
     EXPECT_EQ(pool.available(), 2u);
 }
 
 TEST_F(async_resource_pool_impl, create_const_with_generator_and_capacity_2_then_check_capacity_should_be_2) {
-    const resource_pool_impl pool([]{ return resource{}; }, 2, 0, time_traits::duration::max());
+    const resource_pool_impl pool([]{ return resource{}; }, 2, 0, time_traits::duration::max(), time_traits::duration::max());
 
     EXPECT_EQ(pool.capacity(), 2u);
 }
 
 TEST_F(async_resource_pool_impl, create_const_with_generator_and_capacity_2_then_check_size_should_be_2) {
-    const resource_pool_impl pool([]{ return resource{}; }, 2, 0, time_traits::duration::max());
+    const resource_pool_impl pool([]{ return resource{}; }, 2, 0, time_traits::duration::max(), time_traits::duration::max());
 
     EXPECT_EQ(pool.size(), 2u);
 }
 
 TEST_F(async_resource_pool_impl, create_const_with_generator_and_capacity_2_then_check_available_should_be_2) {
-    const resource_pool_impl pool([]{ return resource{}; }, 2, 0, time_traits::duration::max());
+    const resource_pool_impl pool([]{ return resource{}; }, 2, 0, time_traits::duration::max(), time_traits::duration::max());
 
     EXPECT_EQ(pool.available(), 2u);
 }
 
 
 TEST_F(async_resource_pool_impl, create_const_then_check_stats_should_be_0_0_0_0) {
-    const resource_pool_impl pool(1, 0, time_traits::duration::max());
+    const resource_pool_impl pool(1, 0, time_traits::duration::max(), time_traits::duration::max());
     const async::stats expected {0, 0, 0, 0};
 
     EXPECT_CALL(pool.queue(), size()).WillOnce(Return(0));
@@ -152,7 +152,7 @@ TEST_F(async_resource_pool_impl, create_const_then_check_stats_should_be_0_0_0_0
 }
 
 TEST_F(async_resource_pool_impl, create_const_then_call_queue_should_succeed) {
-    const resource_pool_impl pool(1, 0, time_traits::duration::max());
+    const resource_pool_impl pool(1, 0, time_traits::duration::max(), time_traits::duration::max());
     EXPECT_NO_THROW(pool.queue());
 }
 
@@ -212,7 +212,7 @@ ACTION_P(SaveMoveArg2, ptr) {
 }
 
 TEST_F(async_resource_pool_impl, get_one_should_call_callback) {
-    resource_pool_impl pool(1, 0, time_traits::duration::max());
+    resource_pool_impl pool(1, 0, time_traits::duration::max(), time_traits::duration::max());
 
     mocked_callback_ptr get = std::make_shared<mocked_callback>();
 
@@ -226,7 +226,7 @@ TEST_F(async_resource_pool_impl, get_one_should_call_callback) {
 }
 
 TEST_F(async_resource_pool_impl, get_one_and_recycle_should_make_one_available_resource) {
-    resource_pool_impl pool(1, 0, time_traits::duration::max());
+    resource_pool_impl pool(1, 0, time_traits::duration::max(), time_traits::duration::max());
 
     EXPECT_CALL(executor, post(_)).WillOnce(SaveArg<0>(&on_get));
     EXPECT_CALL(pool.queue(), pop()).WillOnce(Return(ByMove(boost::none)));
@@ -238,7 +238,7 @@ TEST_F(async_resource_pool_impl, get_one_and_recycle_should_make_one_available_r
 }
 
 TEST_F(async_resource_pool_impl, get_one_and_waste_should_make_no_available_resources) {
-    resource_pool_impl pool(1, 0, time_traits::duration::max());
+    resource_pool_impl pool(1, 0, time_traits::duration::max(), time_traits::duration::max());
 
     EXPECT_CALL(executor, post(_)).WillOnce(SaveArg<0>(&on_get));
     EXPECT_CALL(pool.queue(), pop()).WillOnce(Return(ByMove(boost::none)));
@@ -250,7 +250,7 @@ TEST_F(async_resource_pool_impl, get_one_and_waste_should_make_no_available_reso
 }
 
 TEST_F(async_resource_pool_impl, get_twice_and_recycle_should_make_one_available_resource) {
-    resource_pool_impl pool(1, 0, time_traits::duration::max());
+    resource_pool_impl pool(1, 0, time_traits::duration::max(), time_traits::duration::max());
 
     InSequence s;
 
@@ -268,7 +268,7 @@ TEST_F(async_resource_pool_impl, get_twice_and_recycle_should_make_one_available
 }
 
 TEST_F(async_resource_pool_impl, get_twice_and_recycle_should_use_queue_and_make_one_available_resource) {
-    resource_pool_impl pool(1, 0, time_traits::duration::max());
+    resource_pool_impl pool(1, 0, time_traits::duration::max(), time_traits::duration::max());
 
     InSequence s;
 
@@ -287,7 +287,7 @@ TEST_F(async_resource_pool_impl, get_twice_and_recycle_should_use_queue_and_make
 }
 
 TEST_F(async_resource_pool_impl, get_twice_and_recycle_with_zero_idle_timeout_should_use_queue_and_make_one_available_resource) {
-    resource_pool_impl pool(1, 0, time_traits::duration(0));
+    resource_pool_impl pool(1, 0, time_traits::duration(0), time_traits::duration::max());
 
     InSequence s;
 
@@ -306,7 +306,7 @@ TEST_F(async_resource_pool_impl, get_twice_and_recycle_with_zero_idle_timeout_sh
 }
 
 TEST_F(async_resource_pool_impl, get_twice_and_waste_then_get_should_use_queue) {
-    resource_pool_impl pool(1, 0, time_traits::duration::max());
+    resource_pool_impl pool(1, 0, time_traits::duration::max(), time_traits::duration::max());
 
     InSequence s;
 
@@ -342,7 +342,7 @@ struct check_no_error : check_error {
 };
 
 TEST_F(async_resource_pool_impl, get_with_queue_zero_capacity_use_should_return_error) {
-    resource_pool_impl pool(1, 0, time_traits::duration::max());
+    resource_pool_impl pool(1, 0, time_traits::duration::max(), time_traits::duration::max());
 
     InSequence s;
 
@@ -360,7 +360,7 @@ TEST_F(async_resource_pool_impl, get_with_queue_zero_capacity_use_should_return_
 }
 
 TEST_F(async_resource_pool_impl, get_with_queue_use_and_timer_timeout_should_return_error) {
-    resource_pool_impl pool(1, 0, time_traits::duration::max());
+    resource_pool_impl pool(1, 0, time_traits::duration::max(), time_traits::duration::max());
 
     InSequence s;
 
@@ -374,7 +374,7 @@ TEST_F(async_resource_pool_impl, get_with_queue_use_and_timer_timeout_should_ret
 }
 
 TEST_F(async_resource_pool_impl, get_with_queue_use_with_zero_wait_duration_should_return_error) {
-    resource_pool_impl pool(1, 0, time_traits::duration::max());
+    resource_pool_impl pool(1, 0, time_traits::duration::max(), time_traits::duration::max());
 
     InSequence s;
 
@@ -391,7 +391,7 @@ TEST_F(async_resource_pool_impl, get_with_queue_use_with_zero_wait_duration_shou
 }
 
 TEST_F(async_resource_pool_impl, get_after_disable_returns_error) {
-    resource_pool_impl pool(1, 0, time_traits::duration::max());
+    resource_pool_impl pool(1, 0, time_traits::duration::max(), time_traits::duration::max());
 
     InSequence s;
 
@@ -404,7 +404,7 @@ TEST_F(async_resource_pool_impl, get_after_disable_returns_error) {
 }
 
 TEST_F(async_resource_pool_impl, get_recycled_after_disable_returns_error) {
-    resource_pool_impl pool(1, 0, time_traits::duration::max());
+    resource_pool_impl pool(1, 0, time_traits::duration::max(), time_traits::duration::max());
 
     InSequence s;
 
@@ -433,7 +433,7 @@ struct throw_exception {
 };
 
 TEST_F(async_resource_pool_impl, get_and_throw_exception_on_handle_should_pass_exception) {
-    resource_pool_impl pool(1, 0, time_traits::duration::max());
+    resource_pool_impl pool(1, 0, time_traits::duration::max(), time_traits::duration::max());
 
     InSequence s;
 
@@ -449,6 +449,7 @@ public:
     void operator ()(const error_code& err, resource_ptr_list_iterator res) const {
         EXPECT_EQ(err, error_code());
         res->value = resource {};
+        res->reset_time = time_traits::now();
         pool.recycle(res);
     }
 
@@ -456,7 +457,7 @@ private:
     resource_pool_impl& pool;
 };
 
-struct check_is_empty {
+struct assert_empty {
     void operator ()(const error_code& err, resource_ptr_list_iterator res) const {
         EXPECT_EQ(err, error_code());
         EXPECT_FALSE(res->value);
@@ -464,7 +465,7 @@ struct check_is_empty {
 };
 
 TEST_F(async_resource_pool_impl, get_one_set_and_recycle_with_zero_idle_timeout_then_get_should_return_empty) {
-    resource_pool_impl pool(1, 0, time_traits::duration(0));
+    resource_pool_impl pool(1, 0, time_traits::duration(0), time_traits::duration::max());
 
     InSequence s;
 
@@ -474,7 +475,22 @@ TEST_F(async_resource_pool_impl, get_one_set_and_recycle_with_zero_idle_timeout_
     on_first_get();
 
     EXPECT_CALL(executor, post(_)).WillOnce(SaveArg<0>(&on_second_get));
-    pool.get(io, check_is_empty(), time_traits::duration(1));
+    pool.get(io, assert_empty(), time_traits::duration(1));
+    on_second_get();
+}
+
+TEST_F(async_resource_pool_impl, should_waste_resource_when_lifespan_ends) {
+    resource_pool_impl pool(1, 0, time_traits::duration::max(), time_traits::duration(0));
+
+    InSequence s;
+
+    EXPECT_CALL(executor, post(_)).WillOnce(SaveArg<0>(&on_first_get));
+    EXPECT_CALL(pool.queue(), pop()).WillOnce(Return(ByMove(boost::none)));
+    pool.get(io, set_and_recycle_resource(pool));
+    on_first_get();
+
+    EXPECT_CALL(executor, post(_)).WillOnce(SaveArg<0>(&on_second_get));
+    pool.get(io, assert_empty(), time_traits::duration(1));
     on_second_get();
 }
 

--- a/tests/handle.cc
+++ b/tests/handle.cc
@@ -68,7 +68,7 @@ TEST(handle_test, construct_usable_and_move_over_assign_then_destination_should_
 
 TEST(handle_test, construct_usable_then_get_should_return_value) {
     std::list<idle> resources;
-    resources.emplace_back(resource(42), time_traits::time_point());
+    resources.emplace_back(resource(42), time_traits::time_point(), time_traits::time_point());
     auto pool_impl = std::make_shared<StrictMock<pool_impl_mock>>();
     resource_handle handle(pool_impl, &resource_handle::waste, resources.begin());
     EXPECT_EQ(42, handle->value);
@@ -77,7 +77,7 @@ TEST(handle_test, construct_usable_then_get_should_return_value) {
 
 TEST(handle_test, construct_usable_then_get_const_should_return_value) {
     std::list<idle> resources;
-    resources.emplace_back(resource(42), time_traits::time_point());
+    resources.emplace_back(resource(42), time_traits::time_point(), time_traits::time_point());
     auto pool_impl = std::make_shared<StrictMock<pool_impl_mock>>();
     const resource_handle handle(pool_impl, &resource_handle::waste, resources.begin());
     EXPECT_EQ(42, handle->value);


### PR DESCRIPTION
Allows to keep resource value for limited time interval. Each resource has `reset_time` to track time of last change. Resource has been reset if lifespan is elapsed on lease or recycle.