### PR TITLE
Support pool invalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ if (h.empty()) {
 use_resource(h.get());
 ```
 
+#### Invalidate pool
+
+Following method allows to force all available and used handles to be wasted:
+```c++
+void invalidate();
+```
+
+All currently available but not used handles will be wasted. All currently used handles will be wasted on return to the pool.
+
 ### Asynchronous pool
 
 Based on ```boost::asio::io_context```. Uses async queue with deadline timer to store waiting resources requests.
@@ -276,6 +285,15 @@ boost::asio::spawn(io, [&](boost::asio::yield_context yield) {
     use_resource(h.get());
 }
 ```
+
+#### Invalidate pool
+
+Following method allows to force all available and used handles to be wasted:
+```c++
+void invalidate();
+```
+
+All currently available but not used handles will be wasted. All currently used handles will be wasted on return to the pool.
 
 ## Examples
 

--- a/include/yamail/resource_pool/async/detail/pool_impl.hpp
+++ b/include/yamail/resource_pool/async/detail/pool_impl.hpp
@@ -245,6 +245,7 @@ public:
     void recycle(list_iterator res_it) final;
     void waste(list_iterator res_it) final;
     void disable();
+    void invalidate();
 
     static std::size_t assert_capacity(std::size_t value);
 
@@ -387,6 +388,12 @@ void pool_impl<V, M, I, Q>::disable() {
                 std::move(queued->request)
             ));
     }
+}
+
+template <class V, class M, class I, class Q>
+void pool_impl<V, M, I, Q>::invalidate() {
+    const lock_guard lock(_mutex);
+    storage_.invalidate();
 }
 
 template <class V, class M, class I, class Q>

--- a/include/yamail/resource_pool/async/detail/pool_impl.hpp
+++ b/include/yamail/resource_pool/async/detail/pool_impl.hpp
@@ -303,7 +303,11 @@ void pool_impl<V, M, I, Q>::recycle(list_iterator res_it) {
         storage_.recycle(res_it);
         return;
     }
+    const auto valid = storage_.is_valid(res_it);
     lock.unlock();
+    if (!valid) {
+        res_it->value.reset();
+    }
     asio::post(queued->io_context, on_serve_queued_handler(res_it, std::move(queued->request)));
 }
 

--- a/include/yamail/resource_pool/async/pool.hpp
+++ b/include/yamail/resource_pool/async/pool.hpp
@@ -116,6 +116,10 @@ public:
         return init.result.get();
     }
 
+    void invalidate() {
+        _impl->invalidate();
+    }
+
 private:
     using list_iterator = typename pool_impl::list_iterator;
 

--- a/include/yamail/resource_pool/detail/idle.hpp
+++ b/include/yamail/resource_pool/detail/idle.hpp
@@ -16,6 +16,7 @@ struct idle {
     boost::optional<value_type> value;
     time_traits::time_point drop_time;
     time_traits::time_point reset_time;
+    bool waste_on_recycle = false;
 
     idle(time_traits::time_point drop_time = time_traits::time_point::max())
         : drop_time(drop_time) {}

--- a/include/yamail/resource_pool/detail/storage.hpp
+++ b/include/yamail/resource_pool/detail/storage.hpp
@@ -21,6 +21,7 @@ template <class T>
 class storage {
 public:
     using cell_iterator = typename std::list<idle<T>>::iterator;
+    using const_cell_iterator = typename std::list<idle<T>>::iterator;
 
     inline storage(std::size_t capacity, time_traits::duration idle_timeout, time_traits::duration lifespan);
 
@@ -41,6 +42,8 @@ public:
     inline void recycle(cell_iterator cell);
 
     inline void waste(cell_iterator cell);
+
+    inline bool is_valid(const_cell_iterator cell) const;
 
 private:
     time_traits::duration idle_timeout_;
@@ -129,6 +132,16 @@ template <class T>
 void storage<T>::waste(typename storage<T>::cell_iterator cell) {
     cell->value.reset();
     wasted_.splice(wasted_.end(), used_, cell);
+}
+
+template <class T>
+bool storage<T>::is_valid(typename storage<T>::const_cell_iterator cell) const {
+    const auto now = time_traits::now();
+    const auto life_end = time_traits::add(cell->reset_time, lifespan_);
+    if (life_end <= now) {
+        return false;
+    }
+    return true;
 }
 
 } // namespace detail

--- a/include/yamail/resource_pool/sync/detail/pool_impl.hpp
+++ b/include/yamail/resource_pool/sync/detail/pool_impl.hpp
@@ -37,8 +37,16 @@ public:
 
     pool_impl(std::size_t capacity, time_traits::duration idle_timeout, time_traits::duration lifespan)
             : storage_(assert_capacity(capacity), idle_timeout, lifespan),
-              _capacity(capacity),
-              _disabled(false) {
+              _capacity(capacity) {
+    }
+
+    template <class Generator>
+    pool_impl(Generator&& gen_value,
+              std::size_t capacity,
+              time_traits::duration idle_timeout,
+              time_traits::duration lifespan)
+            : storage_(std::forward<Generator>(gen_value), assert_capacity(capacity), idle_timeout, lifespan),
+              _capacity(capacity) {
     }
 
     std::size_t capacity() const { return _capacity; }
@@ -53,6 +61,7 @@ public:
     void recycle(list_iterator res_it) final;
     void waste(list_iterator res_it) final;
     void disable();
+    void invalidate();
 
     static std::size_t assert_capacity(std::size_t value);
 
@@ -65,7 +74,7 @@ private:
     storage_type storage_;
     const std::size_t _capacity;
     condition_variable _has_capacity;
-    bool _disabled;
+    bool _disabled = false;
 
     bool wait_for(unique_lock& lock, time_traits::duration wait_duration);
 };
@@ -143,6 +152,12 @@ typename pool_impl<T, M, C>::get_result pool_impl<T, M, C>::get(time_traits::dur
                                   list_iterator());
         }
     }
+}
+
+template <class T, class M, class C>
+void pool_impl<T, M, C>::invalidate() {
+    const lock_guard lock(_mutex);
+    storage_.invalidate();
 }
 
 template <class T, class M, class C>

--- a/include/yamail/resource_pool/sync/pool.hpp
+++ b/include/yamail/resource_pool/sync/pool.hpp
@@ -57,6 +57,10 @@ public:
         return get_handle(&handle::recycle, wait_duration);
     }
 
+    void invalidate() {
+        _impl->invalidate();
+    }
+
 private:
     using strategy = typename handle::strategy;
     using pool_impl_ptr = std::shared_ptr<pool_impl>;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ if(NOT TARGET googletest AND (NOT GTEST_FOUND OR NOT GMOCK_FOUND))
     ExternalProject_Add(
         googletest
         GIT_REPOSITORY ${GOOGLETEST_REPOSITORY}
-        GIT_TAG release-1.8.0
+        GIT_TAG release-1.10.0
         TIMEOUT 1
         CONFIGURE_COMMAND cmake
             -DCMAKE_BUILD_TYPE=Release

--- a/tests/sync/pool_impl.cc
+++ b/tests/sync/pool_impl.cc
@@ -123,6 +123,8 @@ TEST(sync_resource_pool_impl, get_from_pool_and_wait_then_after_recycle_should_a
     const get_result& first_res = pool.get();
 
     EXPECT_EQ(first_res.first, boost::system::error_code());
+    first_res.second->value = resource {};
+    first_res.second->reset_time = time_traits::now();
 
     InSequence s;
 


### PR DESCRIPTION
Force pool handles to be wasted. Available will be wasted on the method call. Used will be wasted on the next recycle.