### PR TITLE
Boost 1.74 compatibility + Conan updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,14 @@ matrix:
   include:
   - name: conan auto detect
     os: linux
-    dist: xenial
+    dist: bionic
+    addons:
+      apt:
+        packages:
+          - clang-10
+    env:
+      - CXX_COMPILER: clang++-10
+      - BOOST_MINOR: 74
     script:
     - ${TRAVIS_BUILD_DIR}/scripts/travis/conan.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ matrix:
       apt:
         packages:
           - clang-10
+          - python3
+          - python3-pip
     env:
       - CXX_COMPILER: clang++-10
       - BOOST_MINOR: 74

--- a/conanfile.py
+++ b/conanfile.py
@@ -21,8 +21,8 @@ class ResourcePool(ConanFile):
 
     exports_sources = 'include/*', 'CMakeLists.txt', 'resource_poolConfig.cmake', 'LICENCE', 'AUTHORS'
 
-    generators = 'cmake_paths'
-    requires = 'boost/1.71.0@conan/stable'
+    generators = 'cmake_find_package'
+    requires = 'boost/1.74.0'
 
     def _configure_cmake(self):
         cmake = CMake(self)
@@ -41,4 +41,13 @@ class ResourcePool(ConanFile):
         self.info.header_only()
 
     def package_info(self):
-        self.cpp_info.libs = ['resource_pool']
+        self.cpp_info.components["_resource_pool"].includedirs = ["include"]
+        self.cpp_info.components["_resource_pool"].requires = ["boost::boost"]
+        self.cpp_info.components["_resource_pool"].defines = ["BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT"]
+
+        self.cpp_info.filenames["cmake_find_package"] = "resource_pool"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "resource_pool"
+        self.cpp_info.names["cmake_find_package"] = "elsid"
+        self.cpp_info.names["cmake_find_package_multi"] = "elsid"
+        self.cpp_info.components["_resource_pool"].names["cmake_find_package"] = "resource_pool"
+        self.cpp_info.components["_resource_pool"].names["cmake_find_package_multi"] = "resource_pool"

--- a/conanfile.py
+++ b/conanfile.py
@@ -42,7 +42,7 @@ class ResourcePool(ConanFile):
 
     def package_info(self):
         self.cpp_info.components["_resource_pool"].includedirs = ["include"]
-        self.cpp_info.components["_resource_pool"].requires = ["boost::boost"]
+        self.cpp_info.components["_resource_pool"].requires = ["boost::boost", "boost::system", "boost::thread"]
         self.cpp_info.components["_resource_pool"].defines = ["BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT"]
 
         self.cpp_info.filenames["cmake_find_package"] = "resource_pool"

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(resource_pool INTERFACE Boost::system Boost::thread Boost:
 target_compile_definitions(resource_pool
         INTERFACE
         -DBOOST_COROUTINES_NO_DEPRECATION_WARNING
+        -DBOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT
         )
 add_library(elsid::resource_pool ALIAS resource_pool)
 

--- a/scripts/travis/conan.sh
+++ b/scripts/travis/conan.sh
@@ -10,7 +10,7 @@ export CC=/usr/bin/clang-10
 export CXX=/usr/bin/clang++-10
 
 conan profile update settings.compiler=clang default
-conan profile update settings.compiler.version=8 default
+conan profile update settings.compiler.version=10 default
 conan profile update settings.compiler.libcxx=libstdc++11 default
 
 cd "${TRAVIS_BUILD_DIR}"

--- a/scripts/travis/conan.sh
+++ b/scripts/travis/conan.sh
@@ -6,8 +6,8 @@ virtualenv conan-temp
 pip3 install conan
 conan profile new --detect default
 
-export CC=/usr/bin/clang-8
-export CXX=/usr/bin/clang++-8
+export CC=/usr/bin/clang-10
+export CXX=/usr/bin/clang++-10
 
 conan profile update settings.compiler=clang default
 conan profile update settings.compiler.version=8 default

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -3,6 +3,6 @@ project(PackageTest CXX)
 
 find_package(resource_pool REQUIRED)
 
-add_executable(example ../examples/async/strand.cc)
+add_executable(example ../examples/async/coro.cc)
 target_compile_features(example PRIVATE cxx_std_17)
 target_link_libraries(example PRIVATE elsid::resource_pool)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.12)
 project(PackageTest CXX)
 
-include(${CMAKE_BINARY_DIR}/conan_paths.cmake)
 find_package(resource_pool REQUIRED)
 
-add_executable(example ../examples/async/pool.cc)
+add_executable(example ../examples/async/strand.cc)
+target_compile_features(example PRIVATE cxx_std_17)
 target_link_libraries(example PRIVATE elsid::resource_pool)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -3,7 +3,7 @@ from conans import ConanFile, CMake
 
 class ResourcePoolTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake_paths"
+    generators = "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Hi,

this PR includes two changes: The first is rather small, I added `BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT` (see yandex/ozo#266) to the defines of the generated CMake package helper for the time being, so consumers of the library don't have to do it on their end. The `async/coro.cpp` example fails under 1.74 without this, for example.

Other than that, I updated the conan package, so it can be consumed with the `cmake_find_package` generator. Conan does not allow any find helper CMake files into conan-center, so in order to stay comaptible with that, the defines/dependencies using `target_link_libraries` and `target_compile_definitions` need to be replicated in the conanfile. I updated the test package to check for compatibility accordingly.

This should not change anything for users of the current conanfile, as the generated CMake helpers are still included in here and will work with the `conan_paths` generator.

Cheers